### PR TITLE
Update editor.txt

### DIFF
--- a/src/special_pages/editor.txt
+++ b/src/special_pages/editor.txt
@@ -26,6 +26,7 @@ First of all you have to think of each line as a separate entity. You cannot hav
 
 A directive is a line starting with an exclamation point (**!**). Its syntax is like this:
 > !<directive_name> arguments of the directive, altough they could be optional
+
 <directive_name>, as the name suggests, stands for the name of the directive, which can be optionally followed but another line of text.
 Not all planned directives have been implemented yet, so this is open to change.
 You *shouldn't* have to type directive names in lower case, but I think this might be the case for now, until it gets fixed.


### PR DESCRIPTION
Fixes the blockquote in the "Directive" section:
Due to the missing line break the first paragraph after the blockquote wasn't put inside a paragraph element, which messed up the text's margins.